### PR TITLE
Round to nearest minute

### DIFF
--- a/test/tests.ts
+++ b/test/tests.ts
@@ -16,24 +16,33 @@ describe('the moon phases calculation', () => {
         { name: 'fullMoon', phase: 2 },
         { name: 'lastQuarter', phase: 3 },
     ].forEach(({ name, phase }) => {
-        describe(`for ${name}`, () => {
-            it('should return the correct time in UTC', () => {
-                const moonTimes = MSS.yearMoonPhases(2016, phase as MoonPhaseNumber);
-                for (let i = 0; i < moonTimes.length; i++) {
-                    const refTime = dateTimeFromReferenceTime(moonPhases[name][i]);
-                    expect(Math.abs(moonTimes[i].diff(refTime).minutes)).toBeLessThanOrEqual(maxError);
-                }
-            });
+        [true, false].forEach((roundToNearestMinute) => {
+            const testSuffix = roundToNearestMinute ? ' (roundToNearestMinute)' : '';
+            describe(`for ${name}${testSuffix}`, () => {
+                beforeAll(() => {
+                    MSS.settings({ roundToNearestMinute });
+                });
+                afterAll(() => {
+                    MSS.settings({ roundToNearestMinute: !roundToNearestMinute });
+                });
+                it('should return the correct time in UTC', () => {
+                    const moonTimes = MSS.yearMoonPhases(2016, phase as MoonPhaseNumber);
+                    for (let i = 0; i < moonTimes.length; i++) {
+                        const refTime = dateTimeFromReferenceTime(moonPhases[name][i]);
+                        expect(Math.abs(moonTimes[i].diff(refTime).minutes)).toBeLessThanOrEqual(maxError);
+                    }
+                });
 
-            it('should return the correct time in a given timezone', () => {
-                const timezone = 'Pacific/Auckland';
-                const moonTimes = MSS.yearMoonPhases(2016, phase as MoonPhaseNumber, timezone);
-                for (let i = 0; i < moonTimes.length; i++) {
-                    const refTime = dateTimeFromReferenceTime(moonPhases[name][i])
-                        .setZone(timezone);
-                    expect(Math.abs(moonTimes[i].diff(refTime).minutes)).toBeLessThanOrEqual(maxError);
-                    expect(moonTimes[i].toFormat('ZZ ZZZZZ')).toEqual(refTime.toFormat('ZZ ZZZZZ'));
-                }
+                it('should return the correct time in a given timezone', () => {
+                    const timezone = 'Pacific/Auckland';
+                    const moonTimes = MSS.yearMoonPhases(2016, phase as MoonPhaseNumber, timezone);
+                    for (let i = 0; i < moonTimes.length; i++) {
+                        const refTime = dateTimeFromReferenceTime(moonPhases[name][i])
+                            .setZone(timezone);
+                        expect(Math.abs(moonTimes[i].diff(refTime).minutes)).toBeLessThanOrEqual(maxError);
+                        expect(moonTimes[i].toFormat('ZZ ZZZZZ')).toEqual(refTime.toFormat('ZZ ZZZZZ'));
+                    }
+                });
             });
         });
     });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -59,6 +59,31 @@ describe('the moon phases calculation', () => {
 });
 
 describe('the solar events calculations', () => {
+    describe('with `roundToNearestMinute: true`', () => {
+        beforeAll(() => {
+            MSS.settings({ roundToNearestMinute: true });
+        });
+        afterAll(() => {
+            MSS.settings({ roundToNearestMinute: false });
+        });
+
+        it('should return the correct times for sunrise', () => {
+            const { latitude, longitude, timezone, data } = locations[0];
+            const times = data[0];
+            const date = dateTimeFromReferenceTime(times[dataIndices.DATE], timezone);
+            const sunrise = MSS.sunrise(date, latitude, longitude);
+            const refSunrise = getRefEventTime(times[dataIndices.SUNRISE], timezone);
+            expectCorrectTimeOrNoEventCode(date, sunrise, refSunrise);
+        });
+        it('should return the correct times for solar noon', () => {
+            const { latitude, timezone, data } = locations[0];
+            const times = data[0];
+            const date = dateTimeFromReferenceTime(times[dataIndices.DATE], timezone);
+            const solarNoon = MSS.solarNoon(date, latitude);
+            const refSolarNoon = getRefEventTime(times[dataIndices.SOLAR_NOON], timezone);
+            expectCorrectTimeOrNoEventCode(date, solarNoon, refSolarNoon);
+        });
+    });
     locations.forEach(({ latitude, longitude, timezone, name, data }) => {
         describe(`for ${name}`, () => {
             it('should return the correct times for sunrise', () => {


### PR DESCRIPTION
- Testing: `roundToNearestMinute`
- Testing: Sanity check `roundToNearestMinute` with `yearMoonPhases`

While I didn't dig deeply to see whether this setting could make a difference (and a comment seemed to suggest at least in one case it wouldn't), to at least sanity check that the code blocks with the rounding weren't breaking anything, I've added coverage here. But the changes don't distinguish from non-rounding.

(I also didn't add this to repeat with all of the data, as I saw it more of sanity checking.)