### PR TITLE
DeltaT and Thresholds

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,14 @@
 module.exports = {
     collectCoverage: true,
     coverageDirectory: 'coverage',
+    coverageThreshold: {
+        global: {
+            branches: 100,
+            functions: 100,
+            lines: 100,
+            statements: 100,
+        },
+    },
     preset: 'ts-jest',
     setupFilesAfterEnv: ['jest-sorted'],
     testEnvironment: 'node',

--- a/src/timeConversions.ts
+++ b/src/timeConversions.ts
@@ -91,7 +91,7 @@ const DeltaT = (datetime: DateTime): number => {
     let t;
     switch (true) {
         case y < -1999 || y > 3000:
-            throw 'DeltaT can only be calculated between 1999 BCE and 3000 CE';
+            throw new TypeError('DeltaT can only be calculated between 1999 BCE and 3000 CE');
         case y < -500:
             u = (y - 1820) / 100;
             return -20 + 32 * u ** 2;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -16,24 +16,33 @@ describe('the moon phases calculation', () => {
         { name: 'fullMoon', phase: 2 },
         { name: 'lastQuarter', phase: 3 },
     ].forEach(({ name, phase }) => {
-        describe(`for ${name}`, () => {
-            it('should return the correct time in UTC', () => {
-                const moonTimes = MSS.yearMoonPhases(2016, phase as MoonPhaseNumber);
-                for (let i = 0; i < moonTimes.length; i++) {
-                    const refTime = dateTimeFromReferenceTime(moonPhases[name][i]);
-                    expect(Math.abs(moonTimes[i].diff(refTime).minutes)).toBeLessThanOrEqual(maxError);
-                }
-            });
+        [true, false].forEach((roundToNearestMinute) => {
+            const testSuffix = roundToNearestMinute ? ' (roundToNearestMinute)' : '';
+            describe(`for ${name}${testSuffix}`, () => {
+                beforeAll(() => {
+                    MSS.settings({ roundToNearestMinute });
+                });
+                afterAll(() => {
+                    MSS.settings({ roundToNearestMinute: !roundToNearestMinute });
+                });
+                it('should return the correct time in UTC', () => {
+                    const moonTimes = MSS.yearMoonPhases(2016, phase as MoonPhaseNumber);
+                    for (let i = 0; i < moonTimes.length; i++) {
+                        const refTime = dateTimeFromReferenceTime(moonPhases[name][i]);
+                        expect(Math.abs(moonTimes[i].diff(refTime).minutes)).toBeLessThanOrEqual(maxError);
+                    }
+                });
 
-            it('should return the correct time in a given timezone', () => {
-                const timezone = 'Pacific/Auckland';
-                const moonTimes = MSS.yearMoonPhases(2016, phase as MoonPhaseNumber, timezone);
-                for (let i = 0; i < moonTimes.length; i++) {
-                    const refTime = dateTimeFromReferenceTime(moonPhases[name][i])
-                        .setZone(timezone);
-                    expect(Math.abs(moonTimes[i].diff(refTime).minutes)).toBeLessThanOrEqual(maxError);
-                    expect(moonTimes[i].toFormat('ZZ ZZZZZ')).toEqual(refTime.toFormat('ZZ ZZZZZ'));
-                }
+                it('should return the correct time in a given timezone', () => {
+                    const timezone = 'Pacific/Auckland';
+                    const moonTimes = MSS.yearMoonPhases(2016, phase as MoonPhaseNumber, timezone);
+                    for (let i = 0; i < moonTimes.length; i++) {
+                        const refTime = dateTimeFromReferenceTime(moonPhases[name][i])
+                            .setZone(timezone);
+                        expect(Math.abs(moonTimes[i].diff(refTime).minutes)).toBeLessThanOrEqual(maxError);
+                        expect(moonTimes[i].toFormat('ZZ ZZZZZ')).toEqual(refTime.toFormat('ZZ ZZZZZ'));
+                    }
+                });
             });
         });
     });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -59,6 +59,31 @@ describe('the moon phases calculation', () => {
 });
 
 describe('the solar events calculations', () => {
+    describe('with `roundToNearestMinute: true`', () => {
+        beforeAll(() => {
+            MSS.settings({ roundToNearestMinute: true });
+        });
+        afterAll(() => {
+            MSS.settings({ roundToNearestMinute: false });
+        });
+
+        it('should return the correct times for sunrise', () => {
+            const { latitude, longitude, timezone, data } = locations[0];
+            const times = data[0];
+            const date = dateTimeFromReferenceTime(times[dataIndices.DATE], timezone);
+            const sunrise = MSS.sunrise(date, latitude, longitude);
+            const refSunrise = getRefEventTime(times[dataIndices.SUNRISE], timezone);
+            expectCorrectTimeOrNoEventCode(date, sunrise, refSunrise);
+        });
+        it('should return the correct times for solar noon', () => {
+            const { latitude, timezone, data } = locations[0];
+            const times = data[0];
+            const date = dateTimeFromReferenceTime(times[dataIndices.DATE], timezone);
+            const solarNoon = MSS.solarNoon(date, latitude);
+            const refSolarNoon = getRefEventTime(times[dataIndices.SOLAR_NOON], timezone);
+            expectCorrectTimeOrNoEventCode(date, solarNoon, refSolarNoon);
+        });
+    });
     locations.forEach(({ latitude, longitude, timezone, name, data }) => {
         describe(`for ${name}`, () => {
             it('should return the correct times for sunrise', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -25,6 +25,43 @@ describe('the moon phases calculation', () => {
                 afterAll(() => {
                     MSS.settings({ roundToNearestMinute: !roundToNearestMinute });
                 });
+
+                [
+                    ['-1999 <= y < -500', -1050],
+                    ['-500 <= y < 500', -4],
+                    ['500 <= y < 1600 (Pre-Gregorian)', 622],
+                    ['1600 <= y < 1700', 1620],
+                    ['1700 <= y < 1800', 1753],
+                    ['1800 <= y < 1860', 1844],
+                    ['1860 <= y < 1900', 1899],
+                    ['1900 <= y < 1920', 1913],
+                    ['1920 <= y < 1941', 1923],
+                    ['1941 <= y < 1961', 1950],
+                    ['1961 <= y < 1986', 1981],
+                    ['1986 <= y < 2005', 2000],
+                    ['2005 <= y < 2050', 2025],
+                    ['2050 <= y < 2150', 2100],
+                    ['2150 <= y <= 3000', 2151],
+                ].forEach(([text, year]) => {
+                    it(`should handle (${text})`, () => {
+                        const moonTimes = MSS.yearMoonPhases(year as number, phase as MoonPhaseNumber);
+                        expect(moonTimes.length).toBeGreaterThanOrEqual(12);
+                    });
+                });
+
+                [
+                    ['y < -1999', -2000],
+                    ['y > 3000', 3050],
+                ].forEach(([text, year]) => {
+                    it(`should throw when out-of-bounds (${text})`, () => {
+                        expect(() => {
+                            MSS.yearMoonPhases(year as number, phase as MoonPhaseNumber);
+                        }).toThrow(new TypeError(
+                            'DeltaT can only be calculated between 1999 BCE and 3000 CE',
+                        ));
+                    });
+                });
+
                 it('should return the correct time in UTC', () => {
                     const moonTimes = MSS.yearMoonPhases(2016, phase as MoonPhaseNumber);
                     for (let i = 0; i < moonTimes.length; i++) {
@@ -91,6 +128,14 @@ describe('the solar events calculations', () => {
             const solarNoon = MSS.solarNoon(date, latitude);
             const refSolarNoon = getRefEventTime(times[dataIndices.SOLAR_NOON], timezone);
             expectCorrectTimeOrNoEventCode(date, solarNoon, refSolarNoon);
+        });
+    });
+    describe('Pre-Gregorian', () => {
+        it('solar noon', () => {
+            const { latitude, timezone } = locations[0];
+            const date = dateTimeFromReferenceTime('1500-01-01 12:00', timezone);
+            const solarNoon = MSS.solarNoon(date, latitude);
+            expect(solarNoon.hour).toEqual(0);
         });
     });
     locations.forEach(({ latitude, longitude, timezone, name, data }) => {


### PR DESCRIPTION
Builds on #21

- Enhancement: Throw `TypeError` for DeltaT < -1999 or > 3000
- Testing: Pre-Gregorian
- Testing: Check `DeltaT` year categories for `yearMoonPhases`
- Testing: Enforce coverage thresholds to 100%

As with #21, I didn't dig too deeply in this PR to check expected values. I did it more just to do a basic sanity check and bring to 100% coverage.

Even if you only want to add this if it has expected test results, I was hoping this might save some work in pinpointing the method types/arguments that were needed for coverage.