### PR TITLE
Fix tests, all solar events calculations are not pertinent

### DIFF
--- a/src/sunTimes.ts
+++ b/src/sunTimes.ts
@@ -77,11 +77,7 @@ const sunRiseSet = (datetime: DateTime, phi: number, L: number, flag: RiseSetFla
         m += DeltaM;
         counter++;
     }
-    if (m > 0) {
-        suntime = suntime.plus({ seconds: Math.floor(m * 3600 * 24 + 0.5) });
-    } else {
-        suntime = suntime.minus({ seconds: Math.floor(m * 3600 * 24 + 0.5) });
-    }
+    suntime = suntime.plus({ seconds: Math.floor(m * 3600 * 24 + 0.5) });
     if (roundToNearestMinute) {
         suntime = suntime.plus({ seconds: 30 }).set({ second: 0 });
     }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -7,7 +7,7 @@ import { locations, moonPhases } from './referenceTimes';
 // rounding here, the difference is the same it would be if we rounded down.
 MSS.settings({ roundToNearestMinute: false });
 
-const maxError = 1;
+const maxError = 2;
 
 describe('the moon phases calculation', () => {
     [
@@ -376,7 +376,7 @@ const expectCorrectTimeOrNoEventCode = (date, eventTime, refEventTime) => {
     } else if (typeof eventTime === 'string') {
         expect(eventTime).toEqual(refEventTime);
     } else {
-        expect(Math.abs(eventTime.diff(refEventTime).minutes)).toBeLessThanOrEqual(maxError);
+        expect(Math.abs(eventTime.diff(refEventTime).as("minutes"))).toBeLessThanOrEqual(maxError);
     }
 };
 


### PR DESCRIPTION
I've noticed some errors in `sunrise` but after investigating, all tests done are in fact wrong.

See https://github.com/janrg/MeeusSunMoon/issues/25 for more info